### PR TITLE
Add YouTube embed in MDX plugin

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -6,6 +6,7 @@
 
 import {themes as prismThemes} from 'prism-react-renderer';
 
+
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 /** @type {import('@docusaurus/types').Config} */

--- a/website/src/components/mdx/YouTube.tsx
+++ b/website/src/components/mdx/YouTube.tsx
@@ -1,0 +1,20 @@
+// Reference: https://gaudion.dev/blog/mdx-youtube-embed
+// Fixed by Claude to adapted with Docusaurus.
+
+//components/mdx/YouTube.tsx
+export default function YouTube ({ id } : { id : string }){
+  return (
+    <div>
+     <iframe
+      style={{
+          aspectRatio: '16/9',
+          width: '90%'
+      }}
+      className=""
+      src={"https://www.youtube.com/embed/" + id}
+      title="YouTube Video Player"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      ></iframe>
+    </div>
+  );
+};

--- a/website/src/theme/MDXComponents.js
+++ b/website/src/theme/MDXComponents.js
@@ -1,0 +1,9 @@
+// src/theme/MDXComponents.js
+import React from 'react';
+import MDXComponents from '@theme-original/MDXComponents';
+import YouTube from '@site/src/components/mdx/YouTube';
+
+export default {
+  ...MDXComponents,
+  YouTube,
+};


### PR DESCRIPTION
Reference: https://gaudion.dev/blog/mdx-youtube-embed

Fixed by Claude:

For easier use across all docs, create a src/theme/MDXComponents.js file:

```
js// src/theme/MDXComponents.js
import React from 'react';
import MDXComponents from '@theme-original/MDXComponents';
import YouTube from '@site/src/components/YouTube';

export default {
  ...MDXComponents,
  YouTube,
};
```

and the CSS fix to work without Tailwind CSS:

```
<iframe
  style={{
    aspectRatio: '16/9',
    width: '100%'
  }}
```